### PR TITLE
Make dep commits a minor release

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
             {
               "type": "chore",
               "scope": "deps",
-              "release": "patch"
+              "release": "minor"
             }
           ],
           "parserOpts": {


### PR DESCRIPTION
Currently the semantic-release setup is not publishing the package for dependency updates (`core(deps)`) commit message because it is treated as a patch. This changes that behavior to treat these as a `minor` version bump, which will trigger publish.